### PR TITLE
Support for volumes in AWS and GCP

### DIFF
--- a/dss-docker/Dockerfile
+++ b/dss-docker/Dockerfile
@@ -59,7 +59,6 @@ RUN R --slave --no-restore \
 
 # Entry point
 WORKDIR /home/dataiku
-USER dataiku
 
 COPY run.sh /home/dataiku/
 

--- a/dss-docker/run.sh
+++ b/dss-docker/run.sh
@@ -3,10 +3,13 @@
 DSS_INSTALLDIR="/home/dataiku/dataiku-dss-$DSS_VERSION"
 
 if [ ! -f "$DSS_DATADIR"/bin/env-default.sh ]; then
+	echo "Changing the owner of $DSS_DATADIR"
+	chown dataiku:dataiku "$DSS_DATADIR"
+
 	# Initialize new data directory
-	"$DSS_INSTALLDIR"/installer.sh -d "$DSS_DATADIR" -p "$DSS_PORT"
-	"$DSS_DATADIR"/bin/dssadmin install-R-integration
-	echo "dku.registration.channel=docker-image" >>"$DSS_DATADIR"/config/dip.properties
+	su dataiku -c "$DSS_INSTALLDIR/installer.sh -d $DSS_DATADIR -p $DSS_PORT"
+	su dataiku -c "$DSS_DATADIR/bin/dssadmin install-R-integration"
+	su dataiku -c 'echo "dku.registration.channel=docker-image" >>"$DSS_DATADIR"/config/dip.properties'
 
 elif [ $(bash -c 'source "$DSS_DATADIR"/bin/env-default.sh && echo "$DKUINSTALLDIR"') != "$DSS_INSTALLDIR" ]; then
 	# Upgrade existing data directory
@@ -15,4 +18,4 @@ elif [ $(bash -c 'source "$DSS_DATADIR"/bin/env-default.sh && echo "$DKUINSTALLD
 
 fi
 
-exec "$DSS_DATADIR"/bin/dss run
+su dataiku -c 'exec "$DSS_DATADIR"/bin/dss run'


### PR DESCRIPTION
When trying to mount a volume (disk in GCP) to the docker image and installation of app aborts with the following error

> Directory /home/dataiku/dss already exists, but is not empty. Aborting ! 

The current logic in the wrapper script which is run as entry point to the Dataiku-provided Docker image 
    https://github.com/dataiku/dataiku-tools/blob/master/dss-docker/run.sh
looks at the provided data directory for a well-known DSS file in order to automatically determine whether it should install a new instance or upgrade an existing one, as a convenience for an easier use. 
It should be possible to change that in a production environment to adapt to use a EBS volume or a GCP disk. 