### PR TITLE
Install procps package into image in order to provide kill command wh…

### DIFF
--- a/dss-docker/Dockerfile
+++ b/dss-docker/Dockerfile
@@ -13,6 +13,7 @@ RUN useradd -s /bin/bash dataiku \
 # TODO - much could be removed by building externally the required R packages
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        procps \
         locales \
         acl \
         curl \


### PR DESCRIPTION
…ich is required by Dataiku webapps feature to start/stop backend services